### PR TITLE
feat: add Excel and PDF export options

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add CDN libraries for xlsx and jsPDF with autoTable
- allow exporting filtered material lists to Excel with per-section sheets and totals
- allow exporting filtered material lists to branded PDF with headers and page numbers
- tidy site info and remove unused Generate button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa5a7b6a488326962b06241acb5a36